### PR TITLE
Add landing page demo skills

### DIFF
--- a/.claude/skills/landing-page-demo-content-records
+++ b/.claude/skills/landing-page-demo-content-records
@@ -1,0 +1,1 @@
+../../skills/landing-page-demo-content-records

--- a/.claude/skills/landing-page-demo-docs
+++ b/.claude/skills/landing-page-demo-docs
@@ -1,0 +1,1 @@
+../../skills/landing-page-demo-docs

--- a/.claude/skills/landing-page-demo-layout
+++ b/.claude/skills/landing-page-demo-layout
@@ -1,0 +1,1 @@
+../../skills/landing-page-demo-layout

--- a/.claude/skills/landing-page-demo-routing-preview
+++ b/.claude/skills/landing-page-demo-routing-preview
@@ -1,0 +1,1 @@
+../../skills/landing-page-demo-routing-preview

--- a/.claude/skills/landing-page-demo-sections
+++ b/.claude/skills/landing-page-demo-sections
@@ -1,0 +1,1 @@
+../../skills/landing-page-demo-sections

--- a/skills/landing-page-demo-content-records/SKILL.md
+++ b/skills/landing-page-demo-content-records/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: landing-page-demo-content-records
+description: >-
+  Use for existing content collections in the DatoCMS landing page demo starter
+  that feed current routes and sections but are not layout, docs, or section
+  wiring: blog posts, authors, tags, testimonials, pricing tiers, changelog
+  entries, and legal pages. Covers post, author, tag, testimonial, pricing_tier,
+  change_log, and legal_page records; /posts, /posts/[slug], /posts/author/[slug],
+  /posts/tag/[slug], /legal/[slug], /changelog/[slug], PostExcerpt, and section
+  fragments that link these records. Do not use for shared layout, docs pages,
+  new section components, new route-backed types, preview mapping, or generic
+  DatoCMS imports unless the request is tied to these starter records.
+---
+
+# Landing Page Demo Content Records
+
+Use this for existing record collections that power the landing page starter: posts, authors, tags, testimonials, pricing tiers, changelog entries, and legal pages.
+
+## Prerequisites
+
+Before schema or content operations:
+
+- Confirm the shared DatoCMS `agent-skills` plugin is available. If it is missing, ask whether the user already has it installed; if not, request installation before continuing.
+- Expect the DatoCMS MCP to be installed and running. If live schema or content facts are needed and MCP is unavailable, pause and ask the user to install or start it.
+- Inspect live schema/content through MCP before assuming API keys, localized fields, validators, singleton records, or linked records.
+
+## Existing content surfaces
+
+- Posts: `post` records feed `/posts`, `/posts/[slug]`, featured posts sections, all-posts sections, author pages, and tag pages.
+- Authors: `author` records feed `/posts/author/[slug]` and post bylines.
+- Tags: `tag` records feed `/posts/tag/[slug]` and post grouping.
+- Testimonials: `testimonial` records feed `review_section` blocks.
+- Pricing tiers: `pricing_tier` records feed `pricing_section` blocks.
+- Changelog entries: `change_log` records feed `changelog_section` blocks and `/changelog/[slug]`.
+- Legal pages: `legal_page` records feed `/legal/[slug]` and `layout.footer_links`.
+
+## Common workflows
+
+### Add or edit an existing content record
+
+1. Confirm the target record type is one of the existing content collections above.
+2. Inspect the live schema and relevant current records through MCP.
+3. Create or update records through the shared DatoCMS skills or MCP.
+4. Preserve slugs unless the user requests a URL change.
+5. Keep linked records valid: post author, post tags, featured posts, testimonials, pricing tiers, changelog featured versions, and footer legal links.
+6. Publish records when the user expects the change to be public.
+7. Verify the existing route or section that displays the record.
+
+### Change how existing records render
+
+1. Confirm the request changes an existing content surface, not a new section type or new route.
+2. Update the closest existing query, fragment, or component.
+3. Preserve current pagination and locale-aware links.
+4. Regenerate GraphQL types after query changes.
+5. Verify the route and any section that consumes the record.
+
+### Add a content record to an existing section or layout field
+
+1. For records shown inside page body sections, inspect and update the relevant `Page.sections` block.
+2. For legal footer links, inspect and update `layout.footer_links`.
+3. Preserve existing record order unless the user requests a reorder.
+4. Publish parent records when their published output should change.
+
+## Guardrails
+
+- New or changed page body section types belong to `landing-page-demo-sections`.
+- Shared header, footer, navigation, notification, logo, social links, and accent color belong to `landing-page-demo-layout`.
+- Docs home, docs pages, and docs sidebar belong to `landing-page-demo-docs`.
+- New route-backed types, preview links, static params, metadata, and SEO-analysis mapping belong to `landing-page-demo-routing-preview`.
+- Generic schema design and bulk imports belong to the shared DatoCMS skills unless starter rendering is also requested.
+
+## Acceptance criteria
+
+- Existing routes resolve by slug.
+- Linked records remain valid.
+- Published records appear in the intended route or section.
+- Draft/live preview keeps working for draft-enabled records.
+- Pagination still works for post listing changes.
+- GraphQL type generation and build pass after code changes.

--- a/skills/landing-page-demo-content-records/agents/openai.yaml
+++ b/skills/landing-page-demo-content-records/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Landing Page Demo Content Records"
+  short_description: "Adjust site content records"
+  default_prompt: "Use $landing-page-demo-content-records to add or adjust posts, authors, tags, testimonials, pricing tiers, changelog entries, or legal pages in this starter."
+policy:
+  allow_implicit_invocation: true

--- a/skills/landing-page-demo-docs/SKILL.md
+++ b/skills/landing-page-demo-docs/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: landing-page-demo-docs
+description: >-
+  Use for documentation-area work in the DatoCMS landing page demo starter:
+  documentation home, documentation pages, docs tree structure, docs sidebar,
+  highlighted docs pages, docs page Structured Text rendering, docs metadata,
+  and /docs routes. Handles Documentation Home, Documentation Page,
+  app/[locale]/(docs-layout)/**, components/DocumentationSidebarItem/**,
+  components/FeaturedDocumentationPages/**, components/DatoStructuredText/**,
+  QuoteBlock, and docs code/quote rendering. Do not use for regular marketing
+  page sections, shared header/footer/layout, blog/pricing/testimonial/changelog
+  content records, new non-docs routes, or generic DatoCMS schema work.
+---
+
+# Landing Page Demo Docs
+
+Use this for the documentation surface in the landing page starter. Docs are a separate route group with a docs home singleton, tree records, sidebar rendering, and Structured Text rules.
+
+## Prerequisites
+
+Before schema or content operations:
+
+- Confirm the shared DatoCMS `agent-skills` plugin is available. If it is missing, ask whether the user already has it installed; if not, request installation before continuing.
+- Expect the DatoCMS MCP to be installed and running. If live schema or content facts are needed and MCP is unavailable, pause and ask the user to install or start it.
+- Inspect live schema/content through MCP before assuming API keys, localized fields, validators, singleton records, or tree structure.
+
+## Existing docs structure
+
+- Docs home singleton: `documentation_home`.
+- Docs page tree type: `documentation_page`.
+- Docs home route: `app/[locale]/(docs-layout)/docs/`.
+- Docs page route: `app/[locale]/(docs-layout)/docs/[slug]/`.
+- Docs shell query and sidebar: `app/[locale]/(docs-layout)/query.graphql`.
+- Sidebar renderer: `components/DocumentationSidebarItem/**`.
+- Featured docs cards: `components/FeaturedDocumentationPages/**`.
+- Structured Text renderer: `components/DatoStructuredText/**`, with docs-specific rules in the docs page `Content.tsx`.
+
+## Common workflows
+
+### Add or edit docs pages
+
+1. Confirm the request is docs-specific, not a regular marketing page or blog post.
+2. Inspect `documentation_page` fields and the existing tree through MCP.
+3. Create or update the docs page through the shared DatoCMS skills or MCP.
+4. Set parent/child placement when the user asks for sidebar hierarchy.
+5. Preserve existing slugs unless the user explicitly requests a URL change.
+6. Publish the record if the docs page should be public.
+7. Verify `/docs/[slug]`, metadata, and sidebar active state.
+
+### Change docs home
+
+1. Inspect the `documentation_home` singleton through MCP.
+2. Update title, subheader, logo, footer text, or highlighted pages as requested.
+3. Keep highlighted pages linked to valid `documentation_page` records.
+4. Publish the singleton if the change should be public.
+5. Verify `/docs` and featured docs cards.
+
+### Change docs rendering
+
+1. Inspect the existing docs content shape and route component before changing rendering.
+2. Update `DatoStructuredText` usage or docs-specific node rules only for the requested behavior.
+3. Preserve headings, paragraphs, lists, quotes, code blocks, and sidebar behavior.
+4. Regenerate GraphQL types after query changes.
+5. Verify a docs page with representative Structured Text.
+
+## Guardrails
+
+- Regular page sections belong to `landing-page-demo-sections`.
+- Shared header, footer, navigation, notification, logo, social links, and accent color belong to `landing-page-demo-layout`.
+- Posts, authors, tags, testimonials, pricing tiers, changelog entries, and legal pages belong to `landing-page-demo-content-records`.
+- New non-docs routes, preview links, and SEO-analysis mapping belong to `landing-page-demo-routing-preview`.
+- Do not flatten the docs tree unless the user explicitly asks for a structure change.
+
+## Acceptance criteria
+
+- Docs home renders correctly.
+- Docs sidebar reflects the record tree.
+- Docs page routes resolve by slug.
+- Structured Text still handles headings, paragraphs, lists, quotes, and code blocks.
+- Featured docs cards link to valid docs pages.
+- Metadata, GraphQL type generation, and build pass after code changes.

--- a/skills/landing-page-demo-docs/SKILL.md
+++ b/skills/landing-page-demo-docs/SKILL.md
@@ -3,8 +3,8 @@ name: landing-page-demo-docs
 description: >-
   Use for documentation-area work in the DatoCMS landing page demo starter:
   documentation home, documentation pages, docs tree structure, docs sidebar,
-  highlighted docs pages, docs page Structured Text rendering, docs metadata,
-  and /docs routes. Handles Documentation Home, Documentation Page,
+  highlighted docs pages, docs home footer text, docs page Structured Text
+  rendering, docs metadata, and /docs routes. Handles Documentation Home, Documentation Page,
   app/[locale]/(docs-layout)/**, components/DocumentationSidebarItem/**,
   components/FeaturedDocumentationPages/**, components/DatoStructuredText/**,
   QuoteBlock, and docs code/quote rendering. Do not use for regular marketing

--- a/skills/landing-page-demo-docs/agents/openai.yaml
+++ b/skills/landing-page-demo-docs/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Landing Page Demo Docs"
+  short_description: "Adjust documentation pages"
+  default_prompt: "Use $landing-page-demo-docs to add or adjust documentation pages, sidebar structure, or docs home content in this starter."
+policy:
+  allow_implicit_invocation: true

--- a/skills/landing-page-demo-layout/SKILL.md
+++ b/skills/landing-page-demo-layout/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: landing-page-demo-layout
+description: >-
+  Use when changing shared site layout behavior in the DatoCMS landing page demo
+  starter, even if the user does not say layout: header, navigation bar, menu
+  items, dropdown menus, logo, accent color, theme color, top notification bar,
+  footer logo, footer subtitle, footer legal links, social media links, language
+  selector, and fields on the Layout singleton that affect shared shell
+  surfaces. Handles app/[locale]/(common-layout)/query.graphql,
+  app/[locale]/query.graphql, components/Header/**, components/Footer/**, and
+  components/CustomColor/**. Do not use for page body sections, docs pages or
+  docs sidebar, blog/content records, new route-backed pages, preview links, SEO
+  route mapping, or generic DatoCMS schema work.
+---
+
+# Landing Page Demo Layout
+
+Use this for shared site shell behavior in the landing page starter: header, navigation, top notification, logo, accent color, footer, social links, legal footer links, and language selector.
+
+## Prerequisites
+
+Before schema or content operations:
+
+- Confirm the shared DatoCMS `agent-skills` plugin is available. If it is missing, ask whether the user already has it installed; if not, request installation before continuing.
+- Expect the DatoCMS MCP to be installed and running. If live schema or content facts are needed and MCP is unavailable, pause and ask the user to install or start it.
+- Inspect live schema/content through MCP before assuming API keys, localized fields, validators, singleton records, or allowed blocks.
+
+## Existing layout structure
+
+- Shared shell query: `app/[locale]/(common-layout)/query.graphql`.
+- Global color query: `app/[locale]/query.graphql`.
+- Header components: `components/Header/**`.
+- Footer component: `components/Footer/index.tsx`.
+- Accent color component: `components/CustomColor/**`.
+- DatoCMS singleton: `layout`.
+- Layout fields include `logo`, `main_color`, `notification`, `menu`, `footer_logo`, `footer_subtitle`, `social_media_links`, and `footer_links`.
+- Menu blocks are `menu_item` and `menu_dropdown`; social link blocks are `social_media_icon`.
+
+## Common workflows
+
+### Change existing layout content
+
+1. Confirm the request affects a shared shell surface, not one page section or docs content.
+2. Inspect the current `layout` singleton through MCP.
+3. Preserve existing field values and localized values unless the user requested a replacement.
+4. Update the singleton field or nested block shape through the shared DatoCMS skills or MCP.
+5. If the singleton is published and the change should be public, publish it.
+6. Verify a home page and at least one non-home page when practical.
+
+### Add or change layout rendering
+
+1. Inspect the live field shape before changing a query or component.
+2. Update `app/[locale]/(common-layout)/query.graphql` or `app/[locale]/query.graphql` only when more data is needed.
+3. Update the relevant shared component under `components/Header/**`, `components/Footer/**`, or `components/CustomColor/**`.
+4. Keep absent or empty optional fields safe.
+5. Regenerate GraphQL types after query changes.
+6. Verify desktop and mobile navigation when changing menus.
+
+### Adjust navigation or footer
+
+1. For navigation, inspect `layout.menu`, `menu_item`, and `menu_dropdown` records.
+2. Keep menu links route-aware through `buildUrl`.
+3. For footer work, inspect `footer_logo`, `footer_subtitle`, `social_media_links`, and `footer_links`.
+4. Keep legal footer links pointed at `/legal/[slug]` unless route behavior changes too.
+5. Preserve item order unless the user requests a reorder.
+
+## Guardrails
+
+- Page body sections belong to `landing-page-demo-sections`.
+- Docs home, docs pages, and docs sidebar belong to `landing-page-demo-docs`.
+- Blog, author, tag, testimonial, pricing tier, changelog, and legal record maintenance belongs to `landing-page-demo-content-records` unless it changes a shared shell surface.
+- New route-backed types, preview links, metadata, and SEO-analysis mapping belong to `landing-page-demo-routing-preview`.
+- Generic schema design belongs to the shared DatoCMS skills.
+
+## Acceptance criteria
+
+- Header, footer, notification, logo, social links, language selector, and color rendering remain safe with optional empty fields.
+- Menu dropdowns still work on desktop and mobile.
+- Footer links remain locale-aware.
+- GraphQL type generation and build pass after code changes.

--- a/skills/landing-page-demo-layout/agents/openai.yaml
+++ b/skills/landing-page-demo-layout/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Landing Page Demo Layout"
+  short_description: "Adjust shared site layout"
+  default_prompt: "Use $landing-page-demo-layout to change the header, footer, navigation, logo, notification bar, or theme color in this starter."
+policy:
+  allow_implicit_invocation: true

--- a/skills/landing-page-demo-routing-preview/SKILL.md
+++ b/skills/landing-page-demo-routing-preview/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: landing-page-demo-routing-preview
+description: >-
+  Use for route-level infrastructure in the DatoCMS landing page demo starter:
+  adding or changing record-backed routes, static params, metadata, draft/live
+  preview wrappers, Web Previews URL mapping, SEO-analysis route mapping, and
+  route-aware cache/draft behavior. Covers app/[locale]/(common-layout)/**,
+  app/[locale]/(docs-layout)/**, components/WithRealTimeUpdates/**,
+  app/api/draft/preview-links/route.tsx, app/api/seoAnalysis/route.tsx, route
+  query.graphql/meta.ts/page.tsx/Content.tsx/RealTime.tsx files, and optional
+  staticParams.graphql files. Do not use for ordinary page section edits,
+  shared layout content, docs content edits, existing content record changes, or
+  generic Next.js routing outside this starter.
+---
+
+# Landing Page Demo Routing and Preview
+
+Use this for route infrastructure, preview-link mapping, SEO-analysis mapping, metadata, static params, and draft/live preview behavior in the landing page starter.
+
+## Prerequisites
+
+Before schema or content operations:
+
+- Confirm the shared DatoCMS `agent-skills` plugin is available. If it is missing, ask whether the user already has it installed; if not, request installation before continuing.
+- Expect the DatoCMS MCP to be installed and running. If live schema or content facts are needed and MCP is unavailable, pause and ask the user to install or start it.
+- Inspect live schema/content through MCP before assuming API keys, slug fields, localized fields, draft status, SEO fields, or singleton records.
+
+## Existing route pattern
+
+Record-backed route folders normally contain:
+
+- `query.graphql` for the route query.
+- `meta.ts` for generated document/type exports and page prop types.
+- `page.tsx` for variables, metadata, static params when needed, and `generateWrapper`.
+- `Content.tsx` for regular rendering.
+- `RealTime.tsx` for draft/live preview rendering.
+- `staticParams.graphql` for slug-backed collection routes when needed.
+
+Existing route examples:
+
+- Generic pages: `app/[locale]/(common-layout)/[slug]/**`.
+- Posts: `app/[locale]/(common-layout)/posts/[slug]/**`.
+- Authors: `app/[locale]/(common-layout)/posts/author/[slug]/**`.
+- Tags: `app/[locale]/(common-layout)/posts/tag/[slug]/**`.
+- Legal pages: `app/[locale]/(common-layout)/legal/[slug]/**`.
+- Changelog entries: `app/[locale]/(common-layout)/changelog/[slug]/**`.
+- Docs pages: `app/[locale]/(docs-layout)/docs/[slug]/**`.
+
+## Common workflows
+
+### Add a record-backed route
+
+1. Confirm the request needs a new route or route mapping, not only content or section edits.
+2. Inspect the DatoCMS schema type through MCP and confirm slug, localization, draft status, and SEO fields.
+3. Reuse the closest existing route pattern.
+4. Add route query, `meta.ts`, `page.tsx`, `Content.tsx`, and `RealTime.tsx`.
+5. Add `staticParams.graphql` and `generateStaticParams` for slug-backed collection routes.
+6. Add metadata support when the schema type has SEO fields.
+7. Regenerate GraphQL types.
+8. Add preview-link mapping in `app/api/draft/preview-links/route.tsx`.
+9. Add SEO-analysis mapping in `app/api/seoAnalysis/route.tsx` only when the record should support it.
+10. Verify published route, draft preview URL, published preview URL, and metadata.
+
+### Fix preview or SEO-analysis mapping
+
+1. Inspect the record type, slug field, and route path before editing the mapping.
+2. Keep unknown API keys returning no preview links instead of failing.
+3. Preserve locale in generated URLs.
+4. Preserve draft and published preview behavior.
+5. For SEO analysis, return a clear unsupported response for unmapped types.
+6. Verify with a real record when MCP is available.
+
+## Guardrails
+
+- Regular page body sections belong to `landing-page-demo-sections`.
+- Shared header, footer, navigation, notification, logo, social links, and accent color belong to `landing-page-demo-layout`.
+- Docs content and docs tree changes belong to `landing-page-demo-docs` unless route plumbing changes.
+- Existing post, author, tag, testimonial, pricing, changelog, and legal record maintenance belongs to `landing-page-demo-content-records` unless route plumbing changes.
+- Do not add generic routing tutorials; follow this starter's existing wrapper pattern.
+
+## Acceptance criteria
+
+- Published route works.
+- Draft preview opens the correct localized URL.
+- Published preview opens the correct localized URL.
+- Unknown API keys remain safe in preview-link handling.
+- SEO-analysis mapping supports only the intended record types.
+- Metadata uses DatoCMS SEO fields when available.
+- Static params include locales where required.
+- GraphQL type generation and build pass after code changes.

--- a/skills/landing-page-demo-routing-preview/agents/openai.yaml
+++ b/skills/landing-page-demo-routing-preview/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Landing Page Demo Routing Preview"
+  short_description: "Adjust routes and previews"
+  default_prompt: "Use $landing-page-demo-routing-preview to add or fix record-backed routes, preview links, metadata, or SEO-analysis mapping in this starter."
+policy:
+  allow_implicit_invocation: true

--- a/skills/landing-page-demo-sections/SKILL.md
+++ b/skills/landing-page-demo-sections/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: landing-page-demo-sections
+description: >-
+  Use for regular marketing page section work in the DatoCMS landing page demo
+  starter, especially requests to add, remove, reorder, restyle, or wire page
+  sections on Page.records through Page.sections. Covers Hero, Feature List,
+  Brands, Video, Detail, Testimonials, Pricing, Featured Posts, Team, FAQ,
+  Stats, About Intro, All Posts, Redirect, and Changelog section blocks plus
+  their display variants. Handles app/[locale]/(common-layout)/[slug]/query.graphql,
+  app/[locale]/(common-layout)/[slug]/Content.tsx, and
+  components/blocksWithVariants/** fragments/renderers. Do not use for shared
+  header/footer/navigation/theme layout, docs pages/sidebar, existing content
+  record maintenance, route/preview/SEO mapping, or generic DatoCMS schema work.
+---
+
+# Landing Page Demo Sections
+
+Use this for marketing page body sections in the landing page starter. Keep generic DatoCMS schema design and record operations in the shared DatoCMS skills.
+
+## Prerequisites
+
+Before schema or content operations:
+
+- Confirm the shared DatoCMS `agent-skills` plugin is available. If it is missing, ask whether the user already has it installed; if not, request installation before continuing.
+- Expect the DatoCMS MCP to be installed and running. If live schema or content facts are needed and MCP is unavailable, pause and ask the user to install or start it.
+- Inspect live schema/content through MCP before assuming API keys, localized fields, validators, singleton records, or allowed blocks.
+
+## Existing section pattern
+
+Marketing pages use this chain:
+
+1. A DatoCMS block record appears inside localized `page.sections`.
+2. The route query adds an inline fragment in `app/[locale]/(common-layout)/[slug]/query.graphql`.
+3. The block fragment lives under `components/blocksWithVariants/<Typename>/fragment.graphql`.
+4. A React renderer lives under `components/blocksWithVariants/<Typename>/<Variant>/`.
+5. `app/[locale]/(common-layout)/[slug]/Content.tsx` switches on `section.__typename` and display option fields.
+6. GraphQL types are regenerated after query or fragment changes.
+
+Existing section blocks: HeroSection, FeatureListSection, BrandSection, VideoSection, DetailSection, ReviewSection, PricingSection, FeaturedPostsSection, TeamSection, FaqSection, StatsSection, AboutIntro, AllPostsSection, RedirectSection, and ChangelogSection.
+
+## Workflow for section changes
+
+1. Confirm the request is about a regular page body section, not layout, docs, content-record maintenance, or route plumbing.
+2. Inspect the target `Page` record and the `sections` validator through MCP.
+3. Reuse an existing block type and variant when it matches the request.
+4. If a new block type or field is needed, route modeling decisions to `datocms-content-modeling` and schema implementation to the shared DatoCMS implementation skills or MCP.
+5. For end-to-end requests, update the real target `Page.sections` value, not only the code:
+   - preserve existing sections and ordering unless the user specifies placement;
+   - for localized `sections`, update all existing locale values unless the user requested one locale;
+   - reuse existing linked records where possible;
+   - if the page was published and the change should be public, publish the updated record.
+6. Add or update the fragment and renderer under `components/blocksWithVariants/**`.
+7. Update the route query and `Content.tsx` switch with the generated `__typename` and display option value.
+8. Regenerate GraphQL types.
+9. Verify the section in published rendering and draft/live preview.
+
+## Guardrails
+
+- Shared header, footer, navigation, notification, logo, social links, and theme color belong to `landing-page-demo-layout`.
+- Docs home, docs pages, docs sidebar, and docs tree structure belong to `landing-page-demo-docs`.
+- Blog, author, tag, testimonial, pricing tier, changelog, and legal records belong to `landing-page-demo-content-records` unless the renderer itself changes.
+- New route-backed types, preview links, static params, metadata, and SEO-analysis mapping belong to `landing-page-demo-routing-preview`.
+- Keep unknown section types safely ignored.
+
+## Acceptance criteria
+
+- The page query types include the section data.
+- The target `Page.sections` contains the intended block when content work is requested.
+- Localized sections keep the intended locale coverage.
+- The section renders in published mode and draft/live preview.
+- Existing sections still render unchanged.
+- GraphQL type generation and build pass after code changes.

--- a/skills/landing-page-demo-sections/SKILL.md
+++ b/skills/landing-page-demo-sections/SKILL.md
@@ -3,10 +3,12 @@ name: landing-page-demo-sections
 description: >-
   Use for regular marketing page section work in the DatoCMS landing page demo
   starter, especially requests to add, remove, reorder, restyle, or wire page
-  sections on Page.records through Page.sections. Covers Hero, Feature List,
-  Brands, Video, Detail, Testimonials, Pricing, Featured Posts, Team, FAQ,
-  Stats, About Intro, All Posts, Redirect, and Changelog section blocks plus
-  their display variants. Handles app/[locale]/(common-layout)/[slug]/query.graphql,
+  sections on Page.records through Page.sections. Trigger on natural requests
+  such as changing hero variants like split image, right image, background image,
+  or gradient, moving a section on a page, or showing a changelog teaser. Covers
+  Hero, Feature List, Brands, Video, Detail, Testimonials, Pricing, Featured
+  Posts, Team, FAQ, Stats, About Intro, All Posts, Redirect, and Changelog
+  section blocks plus their display variants. Handles app/[locale]/(common-layout)/[slug]/query.graphql,
   app/[locale]/(common-layout)/[slug]/Content.tsx, and
   components/blocksWithVariants/** fragments/renderers. Do not use for shared
   header/footer/navigation/theme layout, docs pages/sidebar, existing content

--- a/skills/landing-page-demo-sections/agents/openai.yaml
+++ b/skills/landing-page-demo-sections/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Landing Page Demo Sections"
+  short_description: "Adjust landing page sections"
+  default_prompt: "Use $landing-page-demo-sections to add or adjust a page body section in this starter."
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
## Summary

- Add five repo-local skills for the landing page demo starter.
- Cover page sections, shared layout, docs, existing content records, and route/preview work.
- Add local discovery metadata and symlinks so the skills are available from both supported client workflows.

## Validation

- Skill validator passed for all five skills.
- Local routing eval passed 70/70 prompt cases.
- Structural coverage eval passed for common prerequisites, guardrails, and project-specific paths.
- Symlink targets resolve to the canonical skill folders.
- Checked new skill files for disallowed naming terms.
- `npm run build` passed.