### PR TITLE
Fix open redirect in next-landing-page-demo draft-mode handlers

### DIFF
--- a/app/api/draft/disable/route.tsx
+++ b/app/api/draft/disable/route.tsx
@@ -1,8 +1,10 @@
 import { cookies, draftMode } from 'next/headers';
 import { redirect } from 'next/navigation';
+import isSafeRedirectUrl from '@/utils/isSafeRedirectUrl';
 
 export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
+  const requestUrl = new URL(request.url);
+  const { searchParams } = requestUrl;
 
   const redirectPath = searchParams.get('redirect');
 
@@ -10,6 +12,9 @@ export async function GET(request: Request) {
   draft.disable();
 
   if (!redirectPath) return new Response('Draft mode is disabled');
+
+  if (!isSafeRedirectUrl(redirectPath, requestUrl))
+    return new Response('URL must be relative!', { status: 422 });
 
   //to avoid losing the cookie on redirect in the iFrame
   const cookieStore = await cookies();

--- a/app/api/draft/enable/route.tsx
+++ b/app/api/draft/enable/route.tsx
@@ -1,9 +1,11 @@
 import { cookies, draftMode } from 'next/headers';
 import { redirect } from 'next/navigation';
 import type { NextRequest } from 'next/server';
+import isSafeRedirectUrl from '@/utils/isSafeRedirectUrl';
 
 export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
+  const requestUrl = new URL(request.url);
+  const { searchParams } = requestUrl;
 
   const token = searchParams.get('token');
   const redirectPath = searchParams.get('redirect');
@@ -15,6 +17,9 @@ export async function GET(request: NextRequest) {
   draft.enable();
 
   if (!redirectPath) return new Response('Draft mode is enabled');
+
+  if (!isSafeRedirectUrl(redirectPath, requestUrl))
+    return new Response('URL must be relative!', { status: 422 });
 
   // By performing a redirect(), we would lose the __prerender_bypass cookie just
   // set by draftMode().enable(), so we would effectively not enter into Next.js's draft mode!

--- a/utils/isSafeRedirectUrl.ts
+++ b/utils/isSafeRedirectUrl.ts
@@ -1,0 +1,25 @@
+/**
+ * Determine whether a user-supplied redirect target is safe to follow — i.e. it
+ * points to the same host as the current request.
+ *
+ * This guards against open-redirect attacks. A naive `url.startsWith('http')`
+ * check — and even a plain "is it a relative URL?" check — fails to catch
+ * protocol-relative targets like `//evil.com` or backslash variants like
+ * `/\evil.com`, both of which browsers happily send off-site.
+ *
+ * Instead, we resolve the candidate against the current request URL and require
+ * the resulting hostname to match. Relative paths (`/foo`, `/a?b=1#c`) resolve
+ * to the same host and pass; anything that escapes to another host — or fails to
+ * parse — is rejected. The scheme is irrelevant: we only compare hostnames.
+ */
+export default function isSafeRedirectUrl(
+  candidate: string,
+  requestUrl: URL,
+): boolean {
+  try {
+    const target = new URL(candidate, requestUrl);
+    return target.hostname === requestUrl.hostname;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Validate the user-supplied `redirect` query param in the draft-mode enable/disable route handlers before redirecting. Both handlers passed the param straight to redirect(), an open-redirect vector — the unauthenticated disable handler being the more exposed.

Add a positive `isSafeRedirectUrl(candidate, requestUrl)` helper that resolves the candidate against the request URL and requires a matching hostname, rejecting protocol-relative (//evil.com) and backslash (/\\evil.com) bypasses that startsWith/relative-URL checks miss.